### PR TITLE
fix multiple countdowns

### DIFF
--- a/countdown/countdown.js
+++ b/countdown/countdown.js
@@ -125,6 +125,7 @@ document.addEventListener("DOMContentLoaded", function() {
     }
 
     function startCountdown(idx) {
+        clearInterval(countdownInterval);
         //TODO: nur ein Countdown gleichzeitgig aktiv:
             // - stoppe alle Countdowns
             // - starte den neuen Countdown


### PR DESCRIPTION
# Hot Fix

Issue: Simultaneous display of multiple countdown timers.

Resolution: Corrected an issue where switching from an active lesson to a new one resulted in both the previous and current lesson countdown timers being visible on the screen.