### PR TITLE
Dev

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -315,6 +315,11 @@ button.current-lesson {
     filter: grayscale(40%);
     background: var(--bg-exam-expired);
 }
+
+.exam-main-completed {
+    background-color: var(--bg-success);
+}
+
 .danger-alert{
     background-color: var(--bg-danger-alert);
     border-style: solid;

--- a/pruefungen/pruefungen.js
+++ b/pruefungen/pruefungen.js
@@ -18,7 +18,17 @@ document.addEventListener('DOMContentLoaded', () => {
         title.className = 'exam-title';
 
         const mainLabel = document.createElement('div');
-        mainLabel.textContent = `Termin: ${formatDateISO(exam.termin)}`;
+        // Statt "Termin: Datum" den Wochentag (deutsch) vor dem formatierten Datum anzeigen.
+        let weekdayText = '';
+        if (exam.termin) {
+            const d = new Date(exam.termin);
+            if (!isNaN(d)) {
+                weekdayText = d.toLocaleDateString('de-DE', { weekday: 'long' });
+                // Ersten Buchstaben groß schreiben (für bessere Darstellung)
+                weekdayText = weekdayText.charAt(0).toUpperCase() + weekdayText.slice(1);
+            }
+        }
+        mainLabel.textContent = weekdayText ? `${weekdayText}: ${formatDateISO(exam.termin)}` : formatDateISO(exam.termin);
         mainLabel.className = 'exam-main-label';
 
         const mainCountdown = document.createElement('div');

--- a/pruefungen/pruefungen.js
+++ b/pruefungen/pruefungen.js
@@ -18,13 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
         title.className = 'exam-title';
 
         const mainLabel = document.createElement('div');
-        // Statt "Termin: Datum" den Wochentag (deutsch) vor dem formatierten Datum anzeigen.
         let weekdayText = '';
         if (exam.termin) {
             const d = new Date(exam.termin);
             if (!isNaN(d)) {
                 weekdayText = d.toLocaleDateString('de-DE', { weekday: 'long' });
-                // Ersten Buchstaben groß schreiben (für bessere Darstellung)
                 weekdayText = weekdayText.charAt(0).toUpperCase() + weekdayText.slice(1);
             }
         }
@@ -36,6 +34,16 @@ document.addEventListener('DOMContentLoaded', () => {
         mainCountdown.textContent = 'Lädt...';
         mainCountdown.dataset.iso = exam.termin || '';
         mainCountdown.dataset.type = 'termin';
+
+        if (exam.termin) {
+            const mainDate = new Date(exam.termin);
+            if (!isNaN(mainDate)) {
+                const now = new Date();
+                if (now >= mainDate) {
+                    container.classList.add('exam-main-completed');
+                }
+            }
+        }
 
         const nachLabel = document.createElement('div');
         nachLabel.className = 'exam-nach-label';
@@ -85,6 +93,42 @@ document.addEventListener('DOMContentLoaded', () => {
             elem.textContent = '';
             return;
         }
+
+        const card = elem.closest('.exam-card');
+        if (card) {
+            const mainElem = card.querySelector('[data-type="termin"]');
+            const nachElem = card.querySelector('[data-type="nach"]');
+            const mainIso = mainElem ? (mainElem.dataset.iso || '') : '';
+            const nachIso = nachElem ? (nachElem.dataset.iso || '') : '';
+
+            const mainDate = mainIso ? new Date(mainIso) : null;
+            const nachDate = nachIso ? new Date(nachIso) : null;
+            const mainPast = mainDate && !isNaN(mainDate) && now >= mainDate;
+            const nachPast = nachDate && !isNaN(nachDate) && now >= nachDate;
+
+            const nachExists = !!nachIso;
+
+            if (mainPast && (nachExists ? nachPast : true)) {
+                if (card.classList.contains('exam-main-completed')) card.classList.remove('exam-main-completed');
+                if (!card.classList.contains('exam-expired')) {
+                    card.classList.add('exam-expired');
+                    card.dataset.fullyExpired = 'true';
+                }
+            } else if (mainPast && (!nachExists || !nachPast)) {
+                if (!card.classList.contains('exam-main-completed')) card.classList.add('exam-main-completed');
+                if (card.classList.contains('exam-expired')) {
+                    card.classList.remove('exam-expired');
+                    delete card.dataset.fullyExpired;
+                }
+            } else {
+                if (card.classList.contains('exam-main-completed')) card.classList.remove('exam-main-completed');
+                if (card.classList.contains('exam-expired')) {
+                    card.classList.remove('exam-expired');
+                    delete card.dataset.fullyExpired;
+                }
+            }
+        }
+
         if (now >= target) {
             let diff = Math.floor((now - target) / 1000);
             const days = Math.floor(diff / (3600 * 24));
@@ -146,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         fullyExpired.forEach((exam) => {
             const {container, mainCountdown, nachCountdown} = createExamCard(exam);
-            // optische Hervorhebung: ausgegraut (CSS-Klasse statt Inline-Styles)
+            if (container.classList.contains('exam-main-completed')) container.classList.remove('exam-main-completed');
             container.classList.add('exam-expired');
             container.dataset.fullyExpired = 'true';
 


### PR DESCRIPTION
This pull request introduces improvements to the handling and display of exam cards, focusing on visual cues for completed and expired exams and enhancing the date labeling for exams. The changes add a new visual state for exams that have passed their main date but not their resit date, and improve the user interface by displaying the weekday for exam dates.

**Exam card state handling and visual improvements:**

* Added a new CSS class `.exam-main-completed` in `assets/style.css` to visually distinguish exams where the main date has passed but the resit date has not.
* Updated logic in `pruefungen/pruefungen.js` to add the `.exam-main-completed` class to exam cards when the main exam date is in the past but the resit date is still upcoming, and to manage the transition between "completed" and "expired" states dynamically. [[1]](diffhunk://#diff-b1853a5e66fd7bb3cdaaf5d82d1a641b49b77f17b7b36b1c12a1a94607321737R38-R47) [[2]](diffhunk://#diff-b1853a5e66fd7bb3cdaaf5d82d1a641b49b77f17b7b36b1c12a1a94607321737R96-R131) [[3]](diffhunk://#diff-b1853a5e66fd7bb3cdaaf5d82d1a641b49b77f17b7b36b1c12a1a94607321737L139-R193)

**User interface enhancements:**

* Modified the main label for each exam to display the weekday (in German) before the date, improving clarity for users about when the exam is scheduled.