### PR TITLE
Update service worker registration path

### DIFF
--- a/countdown/index.html
+++ b/countdown/index.html
@@ -42,7 +42,7 @@
 <script>
   // Register Service Worker
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js')
+    navigator.serviceWorker.register('../assets/sw.js')
             .then(registration => console.log('Service Worker registered'))
             .catch(error => console.log('Service Worker registration failed:', error));
   }

--- a/gauss-jordan/index.html
+++ b/gauss-jordan/index.html
@@ -103,7 +103,7 @@
   <script>
     // Register Service Worker
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js')
+      navigator.serviceWorker.register('../assets/sw.js')
         .then(registration => console.log('Service Worker registered'))
         .catch(error => console.log('Service Worker registration failed:', error));
     }

--- a/pruefungen/index.html
+++ b/pruefungen/index.html
@@ -32,7 +32,7 @@
   <script>
     // Register Service Worker
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js')
+      navigator.serviceWorker.register('../assets/sw.js')
         .then(registration => console.log('Service Worker registered'))
         .catch(error => console.log('Service Worker registration failed:', error));
     }


### PR DESCRIPTION
This pull request updates the registration path for the Service Worker in several HTML files to ensure it correctly references the location of `sw.js`. The change helps the Service Worker to be registered from the appropriate directory, improving reliability across different pages.

**Service Worker registration path updates:**

* Changed the Service Worker registration path from `/sw.js` to `../assets/sw.js` in the following files:
  - `countdown/index.html`
  - `gauss-jordan/index.html`
  - `pruefungen/index.html`